### PR TITLE
Larger gauge view

### DIFF
--- a/DecibelMeter/CircularGaugeView.swift
+++ b/DecibelMeter/CircularGaugeView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A simple circular gauge that scales with its container.
+struct CircularGaugeView: View {
+    /// Current level between 0 and 140 dB.
+    var level: Float
+
+    var body: some View {
+        GeometryReader { geo in
+            let size = geo.size.width * 0.75
+            ZStack {
+                // Background circle
+                Circle()
+                    .stroke(Color.secondary.opacity(0.2), lineWidth: size * 0.05)
+
+                // Progress arc
+                Circle()
+                    .trim(from: 0, to: CGFloat(min(level / 140, 1)))
+                    .stroke(
+                        AngularGradient(
+                            gradient: Gradient(colors: [.cyan, .blue, .purple]),
+                            center: .center
+                        ),
+                        style: StrokeStyle(lineWidth: size * 0.05, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+
+                Text("\(Int(level)) dB")
+                    .font(.system(size: size * 0.2, weight: .bold, design: .rounded))
+            }
+            .frame(width: size, height: size)
+            .position(x: geo.size.width / 2, y: geo.size.height / 2)
+        }
+    }
+}
+
+#Preview {
+    CircularGaugeView(level: 70)
+        .frame(width: 300, height: 300)
+        .padding()
+}

--- a/DecibelMeter/ContentView.swift
+++ b/DecibelMeter/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by David Nyman on 6/23/25.
 //
 import SwiftUI
+import UIKit
 import AVFoundation
 import Accelerate
 import AVFAudio
@@ -169,21 +170,11 @@ struct ContentView: View {
     }
 
     private var scalableGauge: some View {
-        GeometryReader { geo in
-            Gauge(value: Double(meter.level), in: 0...140) {
-                EmptyView()
-            } currentValueLabel: {
-                Text("\(Int(meter.level)) dB")
-                    .font(.system(size: geo.size.width*0.18, weight: .bold, design: .rounded))
-            }
-            .gaugeStyle(.accessoryCircularCapacity)
-            .tint(Gradient(colors: [.cyan, .blue, .purple]))
-            .frame(width: geo.size.width*2.4, height: geo.size.width*2.4)
+        CircularGaugeView(level: meter.level)
+            .frame(width: UIScreen.main.bounds.width * 0.75,
+                   height: UIScreen.main.bounds.width * 0.75)
             .background(.ultraThinMaterial)
             .clipShape(Circle())
-            .position(x: geo.size.width/2, y: geo.size.height/2)
-        }
-        .frame(height: 350) // bigger gauge
     }
 
     private var stats: some View {


### PR DESCRIPTION
## Summary
- introduce `CircularGaugeView` for a scalable decibel meter gauge
- use the new gauge in `ContentView` and size it to 75% of the screen width

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68618c2c72e0833096ae6cad953a2385